### PR TITLE
Correct Typo error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 * [File uploads](https://github.com/Zallom/ShareXenJS#upload-a-file)
 * [File deletion](https://github.com/Zallom/ShareXenJS#delete-a-file)
-* [File uploads](https://github.com/Zallom/ShareXenJS#rename-a-file)
+* [File renaming](https://github.com/Zallom/ShareXenJS#rename-a-file)
 * [File infomations](https://github.com/Zallom/ShareXenJS#get-infomation-from-a-file)
 * [Server informations](https://github.com/Zallom/ShareXenJS#obtain-global-information-from-the-server-used)
 


### PR DESCRIPTION
Changed on `Line 14` from file `README.md`
**from:**
```markdown
* [File uploads](https://github.com/Zallom/ShareXenJS#rename-a-file)
```
**to:**
```markdown
* [File renaming](https://github.com/Zallom/ShareXenJS#rename-a-file)
```